### PR TITLE
add missing css variable documentation

### DIFF
--- a/px-tile.html
+++ b/px-tile.html
@@ -29,6 +29,8 @@ Custom property | Description | Default
 `--px-tile-background-color` | Background color of the title bar at the bottom | `lightgray`
 `--px-tile-overlay-background-color` | Background color for the overlay of a hoverable tile | `black`
 `--px-tile-overlay-text-color` | Text color for the overlay of a hoverable tile | `white`
+`--px-tile-desc-text-height` |  Multi-line truncation effect for description text with the specified rem value | `2rem`
+`--px-tile-text-height`  | Height of the about section (bottom section) | `8.333rem`
 
 
 @element px-tile


### PR DESCRIPTION
# Add missing css variable documentation update 

1. Add css variable description for px tile description text in the about (bottom) section
2. Add height of the about section

@randyaskin @mdwragg @german777   @lizricharson53
